### PR TITLE
fix: avoid crash when columns are undefined

### DIFF
--- a/src/utils/layout-parser.ts
+++ b/src/utils/layout-parser.ts
@@ -185,9 +185,9 @@ export class LayoutParser {
   /**
    * Create multi-column layout approximation - only for genuine multi-column content
    */
-  createColumns(columns: readonly ColumnData[]): string {
+  createColumns(columns?: readonly ColumnData[]): string {
     if (!columns || columns.length <= 1) {
-      return columns[0]?.content || '';
+      return columns?.[0]?.content || '';
     }
 
     // Be much more conservative - only create columns if there's substantial content

--- a/tests/layout-parser.test.ts
+++ b/tests/layout-parser.test.ts
@@ -1,0 +1,11 @@
+const { LayoutParser } = require('../src/utils/layout-parser');
+
+describe('LayoutParser', () => {
+  describe('createColumns', () => {
+    it('should handle undefined columns gracefully', () => {
+      const parser = new LayoutParser();
+      expect(() => parser.createColumns(undefined)).not.toThrow();
+      expect(parser.createColumns(undefined)).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- handle undefined input in LayoutParser.createColumns
- add regression test covering undefined columns case

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a822c077cc832cbc46016630401ffc