### PR TITLE
refactor: remove any types from parsers

### DIFF
--- a/src/parsers/hwp-parser.ts
+++ b/src/parsers/hwp-parser.ts
@@ -1064,6 +1064,8 @@ function extractContentNodes(
 /**
  * Find image reference based on drawing/picture object
  */
+let globalImageCounter = 0;
+
 function findImageReference(
   drawingObj: unknown,
   images: readonly ImageData[],
@@ -1071,8 +1073,8 @@ function findImageReference(
 ): string | null {
   // Reset global counter at the start of each conversion to ensure fresh sequence
   // This is a simple approach - in production you might want a more sophisticated reset mechanism
-  if (images.length > 0 && (!('__globalImageCounter' in findImageReference) || (findImageReference as any).__globalImageCounter >= images.length * 2)) {
-    (findImageReference as any).__globalImageCounter = 0;
+  if (images.length > 0 && globalImageCounter >= images.length * 2) {
+    globalImageCounter = 0;
   }
   if (!images || images.length === 0) return null;
   
@@ -1172,12 +1174,8 @@ function findImageReference(
     
     // If no specific match found, but we do have extracted images, use a global counter
     // to ensure each image reference gets a different image in sequence
-    if (!('__globalImageCounter' in findImageReference)) {
-      (findImageReference as any).__globalImageCounter = 0;
-    }
-    const globalCounter = (findImageReference as any).__globalImageCounter;
-    const selected = images[globalCounter % images.length];
-    (findImageReference as any).__globalImageCounter = globalCounter + 1;
+    const selected = images[globalImageCounter % images.length];
+    globalImageCounter += 1;
     
     if (selected) {
       const imageName = path.basename(selected.savedPath);


### PR DESCRIPTION
## Summary
- eliminate `any` casts in DOCX parser by using typed parser options and results
- replace global counter on `findImageReference` with module variable

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a823a418c8832cb35923c6152acb3e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HWP conversions now select images more predictably when no explicit match is found, cycling through available images to avoid repeats and improve consistency.

* **Refactor**
  * Enhanced DOCX parsing robustness with stricter parsing behavior and safer handling of documents missing a standard wrapper, reducing parsing ambiguities and potential edge-case errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->