### PR TITLE
feat: allow custom output directory for slide images

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,13 +124,14 @@ export async function convert(input: ConvertInput, options: ConvertOptions = {})
     // Setup extractors
     const {
       imageDir = 'images',
+      outputDir = imageDir,
       preserveLayout = true,
       extractCharts = true,
       extractImages = true,
       maxPages
     } = options;
 
-    const imageExtractor = new ImageExtractor(imageDir);
+    const imageExtractor = new ImageExtractor(outputDir);
     const chartExtractor = new ChartExtractor(imageExtractor);
 
     // Parse document based on type
@@ -169,10 +170,11 @@ export async function convert(input: ConvertInput, options: ConvertOptions = {})
       }
       
       case SUPPORTED_MIME_TYPES.PPTX: {
-        const result = await parsePptx(buffer, imageExtractor, chartExtractor, { 
-          preserveLayout, 
-          extractImages, 
-          extractCharts
+        const result = await parsePptx(buffer, imageExtractor, chartExtractor, {
+          preserveLayout,
+          extractImages,
+          extractCharts,
+          outputDir
         });
         markdown = result.markdown;
         images = result.images || [];


### PR DESCRIPTION
## Summary
- allow specifying `outputDir` option for slide images
- use `outputDir` when extracting PPTX slide images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8241c4558832ca88f7800e57a1364